### PR TITLE
Add the ability to close events and a changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ As of version 2.0, this bot is now fully open source!
 You can clone the code and run your own copy, or you can submit pull requests 
 and bug reports to this version to bring them to the `@furryplansbot`.
 
+## Changelog
+See the [Changelog](changelog.md) for the most recent changes!
+
 ## Roadmap
 
 As time allows, I'd like to bring a lot more features to this bot.  
 Here's what is on my roadmap so far:
-- **Closing events:** When an event is over, the ability to close it so no further RSVPing can happen
 - **Migrate to newer DB:** Right now the bot still runs on my old DB. 
 - **More languages and time zones** 
 - **Remove hardcoded URLs** Right now, plansbot.avbrand.com is hardcoded in a few places.

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,13 @@
+Changelog
+
+Version 2.1 - Sep 2023
+- **Ability to close an event.**
+  When an event is closed, attendees can no longer RSVP or change their status, and all sharing buttons are removed.
+
+Version 2.0 - Apr 2023
+- Formatting and emoji in all fields
+- Multiple language support
+- Time zones
+- Faster
+- Rewritten in Golang
+- Open source!

--- a/dbHelper/implement.go
+++ b/dbHelper/implement.go
@@ -504,6 +504,14 @@ func (e *eventConnector) SetSuitwalk(v bool) error {
 	return e.updateEvent("Suitwalk")
 
 }
+func (e *eventConnector) Closed() bool {
+	return e.ev.Closed
+}
+
+func (e *eventConnector) SetClosed(v bool) error {
+	e.ev.Closed = v
+	return e.updateEvent("Closed")
+}
 
 func (e *eventConnector) MaxAttendees() int {
 	return e.ev.MaxAttendees

--- a/dbHelper/schema.go
+++ b/dbHelper/schema.go
@@ -41,6 +41,9 @@ type FurryPlans struct {
 	MaxAttendees int `gorm:"column:MaxAttendees"`
 	DisableMaybe int `gorm:"column:DisableMaybe"`
 	AllowShare   int `gorm:"column:AllowShare"`
+
+	// new items are being added as bools!
+	Closed bool `gorm:"column:Closed"`
 }
 
 // FurryPlansWithAttend is the same as FurryPlans, and doesn't actually represent a table in the DB.

--- a/dbInterface/dbevent_mock.go
+++ b/dbInterface/dbevent_mock.go
@@ -41,6 +41,20 @@ func (_m *DBEventMock) Attending(userId int64, name string, attendType CanAttend
 	return r0
 }
 
+// Closed provides a mock function with given fields:
+func (_m *DBEventMock) Closed() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // DateTime provides a mock function with given fields:
 func (_m *DBEventMock) DateTime() time.Time {
 	ret := _m.Called()
@@ -269,6 +283,20 @@ func (_m *DBEventMock) SavePosting(MessageID string) {
 // SavePostingRegular provides a mock function with given fields: chatId, messageId
 func (_m *DBEventMock) SavePostingRegular(chatId int64, messageId int) {
 	_m.Called(chatId, messageId)
+}
+
+// SetClosed provides a mock function with given fields: v
+func (_m *DBEventMock) SetClosed(v bool) error {
+	ret := _m.Called(v)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool) error); ok {
+		r0 = rf(v)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // SetDateTime provides a mock function with given fields: d

--- a/dbInterface/dbfeatures_mock.go
+++ b/dbInterface/dbfeatures_mock.go
@@ -64,6 +64,32 @@ func (_m *DBFeaturesMock) CreateEvent(OwnerID int64, Name string, DateTime time.
 	return r0, r1
 }
 
+// GetAllUsers provides a mock function with given fields:
+func (_m *DBFeaturesMock) GetAllUsers() ([]int64, error) {
+	ret := _m.Called()
+
+	var r0 []int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]int64, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []int64); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int64)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetEvent provides a mock function with given fields: eventId, ownerId
 func (_m *DBFeaturesMock) GetEvent(eventId uint, ownerId int64) (DBEvent, error) {
 	ret := _m.Called(eventId, ownerId)
@@ -160,6 +186,30 @@ func (_m *DBFeaturesMock) GetPrefs(userid int64) Prefs {
 		r0 = rf(userid)
 	} else {
 		r0 = ret.Get(0).(Prefs)
+	}
+
+	return r0
+}
+
+// GlobalMarkBadUser provides a mock function with given fields: id
+func (_m *DBFeaturesMock) GlobalMarkBadUser(id int64) {
+	_m.Called(id)
+}
+
+// GlobalSent provides a mock function with given fields: id
+func (_m *DBFeaturesMock) GlobalSent(id int64) {
+	_m.Called(id)
+}
+
+// GlobalShouldSend provides a mock function with given fields: id
+func (_m *DBFeaturesMock) GlobalShouldSend(id int64) bool {
+	ret := _m.Called(id)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(int64) bool); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
 
 	return r0

--- a/dbInterface/dbinterface.go
+++ b/dbInterface/dbinterface.go
@@ -53,6 +53,8 @@ type DBEvent interface {
 	SetLanguage(t string) error
 	Suitwalk() bool
 	SetSuitwalk(v bool) error
+	Closed() bool
+	SetClosed(v bool) error
 	MaxAttendees() int
 	SetMaxAttendees(i int) error
 	DisableMaybe() bool
@@ -100,6 +102,7 @@ const (
 	ATTEND_REMOVED
 	ATTEND_FULL
 	ATTEND_ACTIVE
+	ATTEND_CLOSED
 )
 
 type Prefs struct {

--- a/tgPlansBot/buttons.go
+++ b/tgPlansBot/buttons.go
@@ -270,6 +270,13 @@ func eventEditButtons(event dbInterface.DBEvent, loc *localizer.Localizer) tgbot
 	row = append(row, quickButton(loc.Sprintf("💔 Allow Maybe: %v", iif(event.DisableMaybe(), loc.Sprintf("No"), loc.Sprintf("Yes"))), fmt.Sprintf("edit:%v:setmaybe", event.ID())))
 	buttons = append(buttons, row)
 
+	// If event is closed, show a button to reopen
+	if event.Closed() {
+		row = make([]tgbotapi.InlineKeyboardButton, 0)
+		row = append(row, quickButton(loc.Sprintf("🏁 Event is closed. Reopen!"), fmt.Sprintf("edit:%v:reopen", event.ID())))
+		buttons = append(buttons, row)
+	}
+
 	row = make([]tgbotapi.InlineKeyboardButton, 0)
 	row = append(row, quickButton(loc.Sprintf("📩 Allow Sharing: %v", iif(event.SharingAllowed(), loc.Sprintf("Yes"), loc.Sprintf("No"))), fmt.Sprintf("edit:%v:sharing", event.ID())))
 	row = append(row, quickButton(loc.Sprintf("⚙ Advanced Options..."), fmt.Sprintf("edit:%v:advanced", event.ID())))
@@ -296,6 +303,12 @@ func eventAdvancedButtons(event dbInterface.DBEvent, loc *localizer.Localizer) t
 	row[0] = quickButton(loc.Sprintf("🔠 Language"), fmt.Sprintf("edit:%v:language", event.ID()))
 	row[1] = quickButton(loc.Sprintf("⌚ Time Zone"), fmt.Sprintf("edit:%v:timezone", event.ID()))
 	buttons = append(buttons, row)
+
+	if !event.Closed() { // Only show a Close button when the event isn't already closed.
+		row = make([]tgbotapi.InlineKeyboardButton, 1)
+		row[0] = quickButton(loc.Sprintf("❌ Close Event"), fmt.Sprintf("edit:%v:close", event.ID()))
+		buttons = append(buttons, row)
+	}
 
 	row = make([]tgbotapi.InlineKeyboardButton, 1)
 	row[0] = quickButton(loc.Sprintf("🔙 Back"), fmt.Sprintf("edit:%v:back", event.ID()))

--- a/tgPlansBot/eventedit.go
+++ b/tgPlansBot/eventedit.go
@@ -94,6 +94,10 @@ func (tgp *TGPlansBot) manage_clickEdit(usrInfo *userManager.UserInfo, cb *tgbot
 		tgp.toggleItem(usrInfo, cb, event.DisableMaybe(), event.SetDisableMaybe, event)
 	case "suitwalk":
 		tgp.toggleItem(usrInfo, cb, event.Suitwalk(), event.SetSuitwalk, event)
+	case "close": // When the event is no longer accepting attendees
+		tgp.toggleItem(usrInfo, cb, false, event.SetClosed, event)
+	case "reopen": // Reopen after closing
+		tgp.toggleItem(usrInfo, cb, true, event.SetClosed, event)
 
 	// COMMANDS
 	case "advanced":


### PR DESCRIPTION
- **Ability to close an event.**
  When an event is closed, attendees can no longer RSVP or change their status, and all sharing buttons are removed.