### PR TITLE
fix(localizer): make some corrections to the French locales

### DIFF
--- a/localizer/locale.go
+++ b/localizer/locale.go
@@ -17,6 +17,8 @@ const (
 	usTimeFormat     = "3:04 PM"
 	euDateFormat     = "Monday, 2. January 2006, 15:04"
 	euTimeFormat     = "15:04"
+	frDateFormat     = "Monday 2 January 2006, 15 h 04"
+	frTimeFormat     = "15 h 04"
 )
 
 type Localizer struct {
@@ -42,15 +44,15 @@ func InitLang() {
 		"fr-FR": { // France (French)
 			name:       "Français (France)",
 			iso639code: "fr",
-			dateFormat: euDateFormat,
-			timeFormat: euTimeFormat,
+			dateFormat: frDateFormat,
+			timeFormat: frTimeFormat,
 			printer:    message.NewPrinter(language.MustParse("fr-FR")),
 		},
 		"fr-CA": { // Canada (French)
 			name:       "Français (Québec)",
 			iso639code: "fr",
-			dateFormat: euDateFormat,
-			timeFormat: euTimeFormat,
+			dateFormat: frDateFormat,
+			timeFormat: frTimeFormat,
 			printer:    message.NewPrinter(language.MustParse("fr-CA")),
 		},
 		"en-US": { // United States

--- a/localizer/locale.go
+++ b/localizer/locale.go
@@ -40,14 +40,14 @@ func InitLang() {
 			printer:    message.NewPrinter(language.MustParse("de-DE")),
 		},
 		"fr-FR": { // France (French)
-			name:       "Française (France)",
+			name:       "Français (France)",
 			iso639code: "fr",
 			dateFormat: euDateFormat,
 			timeFormat: euTimeFormat,
 			printer:    message.NewPrinter(language.MustParse("fr-FR")),
 		},
 		"fr-CA": { // Canada (French)
-			name:       "Française (Quebec)",
+			name:       "Français (Québec)",
 			iso639code: "fr",
 			dateFormat: euDateFormat,
 			timeFormat: euTimeFormat,


### PR DESCRIPTION
This PR
- fixes the language names for French to be grammatically correct
  - while it's true that "langue" is grammatically feminine, when referring to languages by name on their own (and not as adjectives), they are invariant.
  - see: https://en.wiktionary.org/wiki/fran%C3%A7ais#Noun
- improves the date/time formats for French to follow OQLF and GC recommendations
  - see: https://www.noslangues-ourlanguages.gc.ca/en/cles-de-la-redaction/date-regles-decriture, https://www.noslangues-ourlanguages.gc.ca/en/cles-de-la-redaction/heure-ecriture-de-lheure, and https://vitrinelinguistique.oqlf.gouv.qc.ca/21242/la-typographie/nombres/ecriture-des-dates-et-des-heures-dans-les-lettres-et-les-textes-courants
  - deviation: I've omitted using non-breaking spaces in the date format due to Telegram typically being used in fairly narrow screens; the time format does include non-breaking spaces around the 'h', however.